### PR TITLE
Update GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
 


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use upload-pages-artifact@v3 instead of v2, which is now deprecated and causing the workflow to fail.